### PR TITLE
Update coraza engine for libcoraza >= 1.4.0

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,12 +1,12 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* Define to 1 if you have the <coraza/core.h> header file. */
-#undef HAVE_CORAZA_CORE_H
+/* Define to 1 if you have the <coraza/coraza.h> header file. */
+#undef HAVE_CORAZA_CORAZA_H
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `libcorazacore' library (-lcorazacore). */
+/* Define to 1 if you have the `libcoraza' library (-lcoraza). */
 #undef HAVE_LIBCORAZA
 
 /* Define to 1 if you have the 'yaml' library (-lyaml). */

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_PROG_CC
 # Checks for header files.
 
 AC_CHECK_HEADERS([modsecurity/modsecurity.h], [], [AC_MSG_NOTICE([unable to find header modsecurity/modsecurity.h])])
-AC_CHECK_HEADERS([coraza/core.h], [], [AC_MSG_NOTICE([unable to find header coraza/core.h])])
+AC_CHECK_HEADERS([coraza/coraza.h], [], [AC_MSG_NOTICE([unable to find header coraza/coraza.h])])
 AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8], [Define the PCRE2 code unit width])
 AC_CHECK_HEADERS([pcre2.h], [], [AC_MSG_ERROR([unable to find header pcre2.h], 1)])
 AC_CHECK_HEADERS([yaml.h], [], [AC_MSG_ERROR([unable to find header yaml.h], 1)])
@@ -38,21 +38,21 @@ AC_CHECK_LIB([modsecurity],
              ],
              AC_MSG_NOTICE([libmodsecurity is not installed.])
 )
-AC_CHECK_LIB([corazacore],
-             [coraza_new_waf],
+AC_CHECK_LIB([coraza],
+             [coraza_new_waf_config],
              [
                  AC_DEFINE([HAVE_LIBCORAZA],
                            [1],
-                           [Define to 1 if you have the `libcorazacore' library (-lcorazacore).])
-                 AC_SUBST([LIBCORAZA_LIB], [-lcorazacore])
+                           [Define to 1 if you have the `libcoraza' library (-lcoraza).])
+                 AC_SUBST([LIBCORAZA_LIB], [-lcoraza])
                  has_coraza=yes
              ],
-             AC_MSG_NOTICE([libcorazacore is not installed.])
+             AC_MSG_NOTICE([libcoraza is not installed.])
 )
 
 AS_IF([test "x$has_modsecurity" = xno], 
     AS_IF([test "x$has_coraza" = xno],
-        [AC_MSG_ERROR([neither libmodsecurity nor libcorazacore is installed.], 1)]
+        [AC_MSG_ERROR([neither libmodsecurity nor libcoraza is installed.], 1)]
     )
 )
 

--- a/coraza.conf.example
+++ b/coraza.conf.example
@@ -1,0 +1,4 @@
+SecRuleEngine On
+SecRequestBodyAccess On
+SecResponseBodyAccess On
+SecResponseBodyMimeType text/plain text/html text/xml application/json

--- a/coraza_includes.conf.example
+++ b/coraza_includes.conf.example
@@ -1,0 +1,5 @@
+include coraza.conf
+include /path/to/coreruleset/crs-setup.conf.example
+include /path/to/coreruleset/plugins/empty-before.conf
+include /path/to/coreruleset/rules/*.conf
+include /path/to/coreruleset/plugins/empty-after.conf

--- a/ftwrunner-coraza.yaml.example
+++ b/ftwrunner-coraza.yaml.example
@@ -1,0 +1,2 @@
+modsecurity_config: coraza_includes.conf
+ftwtest_root: /path/to/coreruleset/tests/regression/tests

--- a/src/engines/engines.c
+++ b/src/engines/engines.c
@@ -36,11 +36,6 @@
 #endif
 #endif
 
-#ifdef HAVE_LIBCORAZA
-#include <coraza/core.h>
-#include <coraza/utils.h>
-#endif
-
 #include "ftwcoraza/ftwcoraza.h"
 #include "ftwmodsecurity/ftwmodsecurity.h"
 #include "ftwdummy/ftwdummy.h"

--- a/src/engines/engines.c
+++ b/src/engines/engines.c
@@ -378,7 +378,13 @@ void ftw_engine_show_result(const ftw_engine * engine) {
     printf("\n");
     printf("SUMMARY\n");
     printf("===============================\n");
-    printf("ENGINE:                 %s\n", engine->engine_type == FTW_ENGINE_TYPE_DUMMY ? "Dummy" : "ModSecurity");
+    const char *engine_name = "Unknown";
+    switch(engine->engine_type) {
+        case FTW_ENGINE_TYPE_DUMMY:        engine_name = "Dummy"; break;
+        case FTW_ENGINE_TYPE_MODSECURITY:  engine_name = "ModSecurity"; break;
+        case FTW_ENGINE_TYPE_CORAZA:       engine_name = "Coraza"; break;
+    }
+    printf("ENGINE:                 %s\n", engine_name);
     printf("PASSED:                 %d\n", engine->cnt_passed);
     printf("FAILED:                 %d\n", engine->cnt_failed);
     printf("FAILED (whitelisted):   %d\n", engine->cnt_failedwl);

--- a/src/engines/engines.c
+++ b/src/engines/engines.c
@@ -359,8 +359,8 @@ void ftw_engine_free(ftw_engine * engine) {
 #endif
 #ifdef HAVE_LIBCORAZA
             case FTW_ENGINE_TYPE_CORAZA:
-                if (engine->engine_instance != NULL) {
-                    coraza_free_waf((coraza_waf_t *)engine->engine_instance);
+                if (engine->rules != NULL) {
+                    coraza_free_waf((coraza_waf_t)(uintptr_t)engine->rules);
                 }
                 free(engine);
                 break;

--- a/src/engines/engines.c
+++ b/src/engines/engines.c
@@ -360,7 +360,7 @@ void ftw_engine_free(ftw_engine * engine) {
 #ifdef HAVE_LIBCORAZA
             case FTW_ENGINE_TYPE_CORAZA:
                 if (engine->rules != NULL) {
-                    coraza_free_waf((coraza_waf_t)(uintptr_t)engine->rules);
+                    coraza_free_waf((coraza_waf_t)engine->rules);
                 }
                 free(engine);
                 break;

--- a/src/engines/ftwcoraza/ftwcoraza.c
+++ b/src/engines/ftwcoraza/ftwcoraza.c
@@ -23,9 +23,20 @@
 
 #ifdef HAVE_LIBCORAZA
 
+// error callback for coraza - captures matched rule error logs
+static void coraza_error_log_cb(void *ctx, coraza_matched_rule_t rule) {
+    (void)ctx;
+    char *error_log = coraza_matched_rule_get_error_log(rule);
+    if (error_log != NULL) {
+        logCbText(NULL, error_log);
+        free(error_log);
+    }
+}
+
 // init coraza WAF config
 void * ftw_engine_init_coraza() {
     coraza_waf_config_t config = coraza_new_waf_config();
+    coraza_add_error_callback(config, coraza_error_log_cb, NULL);
     return (void*)(uintptr_t)config;
 }
 
@@ -160,6 +171,43 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
                 printf("%s\n", log);
             }
             free(log);
+        }
+    }
+    if (stage->output->log->expect_ids_len > 0) {
+        for(int i = 0; i < stage->output->log->expect_ids_len; i++) {
+            char idsubj[50];
+            sprintf(idsubj, "id \"%u\"", stage->output->log->expect_ids[i]);
+            log = logContains(idsubj, 0);
+            if (log != NULL) {
+                ret = FTW_TEST_PASS;
+                if (debug == 1) {
+                    printf("%s\n", log);
+                }
+                free(log);
+            }
+            else {
+                ret = FTW_TEST_FAIL;
+                if (debug == 1) {
+                    printf("Log no contains required pattern: '%s'\n", idsubj);
+                }
+            }
+        }
+    }
+    if (stage->output->log->no_expect_ids_len > 0) {
+        for(int i = 0; i < stage->output->log->no_expect_ids_len; i++) {
+            char idsubj[50];
+            sprintf(idsubj, "id \"%u\"", stage->output->log->no_expect_ids[i]);
+            log = logContains(idsubj, 1);
+            if (log == NULL) {
+                ret = FTW_TEST_PASS;
+            }
+            else {
+                ret = FTW_TEST_FAIL;
+                if (debug == 1) {
+                    printf("%s\n", log);
+                }
+                free(log);
+            }
         }
     }
 

--- a/src/engines/ftwcoraza/ftwcoraza.c
+++ b/src/engines/ftwcoraza/ftwcoraza.c
@@ -23,21 +23,37 @@
 
 #ifdef HAVE_LIBCORAZA
 
-// init coraza WAF
+// init coraza WAF config
 void * ftw_engine_init_coraza() {
-    coraza_waf_t *coraza = coraza_new_waf();
-    return (void*)coraza;
+    coraza_waf_config_t config = coraza_new_waf_config();
+    return (void*)(uintptr_t)config;
 }
 
-// set the rules
+// set the rules and create WAF
 void * ftw_engine_create_rules_set_coraza(void * engine_instance, char * main_rule_uri, const char ** error) {
-    coraza_rules_add_file((coraza_waf_t *) engine_instance, main_rule_uri, (char **)error);
-    return NULL;
+    coraza_waf_config_t config = (coraza_waf_config_t)(uintptr_t)engine_instance;
+
+    if (coraza_rules_add_file(config, main_rule_uri) < 0) {
+        *error = "failed to add rules file";
+        coraza_free_waf_config(config);
+        return NULL;
+    }
+
+    char *waf_error = NULL;
+    coraza_waf_t waf = coraza_new_waf(config, &waf_error);
+    coraza_free_waf_config(config);
+
+    if (waf == 0) {
+        *error = waf_error ? waf_error : "failed to create WAF";
+        return NULL;
+    }
+
+    return (void*)(uintptr_t)waf;
 }
 
 // cleanup the resources
 void ftw_engine_cleanup_coraza(void * waf) {
-    coraza_free_waf((coraza_waf_t *)waf);
+    coraza_free_waf((coraza_waf_t)(uintptr_t)waf);
 }
 
 // run a transaction

--- a/src/engines/ftwcoraza/ftwcoraza.c
+++ b/src/engines/ftwcoraza/ftwcoraza.c
@@ -37,12 +37,12 @@ static void coraza_error_log_cb(void *ctx, coraza_matched_rule_t rule) {
 void * ftw_engine_init_coraza() {
     coraza_waf_config_t config = coraza_new_waf_config();
     coraza_add_error_callback(config, coraza_error_log_cb, NULL);
-    return (void*)(uintptr_t)config;
+    return (void*)config;
 }
 
 // set the rules and create WAF
 void * ftw_engine_create_rules_set_coraza(void * engine_instance, char * main_rule_uri, const char ** error) {
-    coraza_waf_config_t config = (coraza_waf_config_t)(uintptr_t)engine_instance;
+    coraza_waf_config_t config = (coraza_waf_config_t)engine_instance;
 
     if (coraza_rules_add_file(config, main_rule_uri) < 0) {
         *error = "failed to add rules file";
@@ -59,12 +59,12 @@ void * ftw_engine_create_rules_set_coraza(void * engine_instance, char * main_ru
         return NULL;
     }
 
-    return (void*)(uintptr_t)waf;
+    return (void*)waf;
 }
 
 // cleanup the resources
 void ftw_engine_cleanup_coraza(void * waf) {
-    coraza_free_waf((coraza_waf_t)(uintptr_t)waf);
+    coraza_free_waf((coraza_waf_t)waf);
 }
 
 // run a transaction
@@ -75,7 +75,7 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
 
     coraza_intervention_t *it;
     coraza_transaction_t transaction = 0;
-    coraza_waf_t waf = (coraza_waf_t)(uintptr_t)engine->rules;
+    coraza_waf_t waf = (coraza_waf_t)engine->rules;
 
     logCbClearLog();
     transaction = coraza_new_transaction(waf);

--- a/src/engines/ftwcoraza/ftwcoraza.c
+++ b/src/engines/ftwcoraza/ftwcoraza.c
@@ -63,10 +63,11 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
     int ret = FTW_TEST_FAIL;
 
     coraza_intervention_t *it;
-    coraza_transaction_t *transaction = NULL;
+    coraza_transaction_t transaction = 0;
+    coraza_waf_t waf = (coraza_waf_t)(uintptr_t)engine->rules;
 
     logCbClearLog();
-    transaction = coraza_new_transaction((coraza_waf_t*) engine->engine_instance, logCbText);
+    transaction = coraza_new_transaction(waf);
 
     // phase 0
     coraza_process_connection(transaction, "127.0.0.1", 33333, stage->input->dest_addr, stage->input->port);
@@ -79,6 +80,7 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
     }
     coraza_process_uri(transaction, stage->input->uri, stage->input->method, version);
     it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     // phase 1
     for(int hi = 0; hi < stage->input->headers_len; hi++) {
@@ -92,40 +94,42 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
     }
     coraza_add_request_header(transaction, "X-CRS-Test", 10, title, (int)strlen(title));
     coraza_process_request_headers(transaction);
-    it = coraza_intervention(transaction); // cppcheck-suppress redundantAssignment
+    it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     // phase 2
     if (stage->input->data != NULL) {
         coraza_append_request_body(transaction, (unsigned char *)stage->input->data, strlen(stage->input->data));
     }
     coraza_process_request_body(transaction);
-    it = coraza_intervention(transaction); // cppcheck-suppress redundantAssignment
+    it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     // phase 3
     char response_len[10];
-    sprintf(response_len, "%ld", stage->output->response_len); 
-    coraza_add_response_header(transaction, "Date",            4, stage->output->response_date, (int)strlen(stage->output->response_date));
+    sprintf(response_len, "%ld", stage->response->response_len);
+    if (stage->response->response_date != NULL) {
+        coraza_add_response_header(transaction, "Date", 4, stage->response->response_date, (int)strlen(stage->response->response_date));
+    }
     coraza_add_response_header(transaction, "Server",          6, "Ftwrunner", 9);
     coraza_add_response_header(transaction, "Content-Type",   12, "text/html; charset=UTF-8", 24);
     coraza_add_response_header(transaction, "Content-Length", 14, response_len, (int)strlen(response_len));
-    coraza_process_response_headers(transaction, stage->output->response_code, (char *)"HTTP/1.1");
-    it = coraza_intervention(transaction); // cppcheck-suppress redundantAssignment
+    coraza_process_response_headers(transaction, stage->response->response_code, (char *)"HTTP/1.1");
+    it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     // phase 4
-    if (stage->output->response != NULL) {
-        coraza_append_response_body(transaction, (unsigned char *)stage->output->response, stage->output->response_len);
+    if (stage->response->response_body != NULL) {
+        coraza_append_response_body(transaction, stage->response->response_body, stage->response->response_len);
     }
     coraza_process_response_body(transaction);
-    it = coraza_intervention(transaction); // cppcheck-suppress redundantAssignment
+    it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     // phase 5
     coraza_process_logging(transaction);
-    it = coraza_intervention(transaction); // cppcheck-suppress redundantAssignment
-    if (it != NULL) {
-        if (it->log != NULL) {
-            free(it->log);
-        }
-    }
+    it = coraza_intervention(transaction);
+    if (it != NULL) { coraza_free_intervention(it); }
 
     //logCbDump();
     char * log = NULL;
@@ -145,7 +149,7 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
             }
         }
     }
-    else if (stage->output->no_log_contains != NULL) {
+    if (stage->output->no_log_contains != NULL) {
         log = logContains(stage->output->no_log_contains, 1);
         if (log == NULL) {
             ret = FTW_TEST_PASS;
@@ -159,15 +163,10 @@ int ftw_engine_runtest_coraza(ftw_engine * engine, char * title, ftw_stage *stag
         }
     }
 
-    /*if (it->url != NULL) {
-        free(it->url);
-    }
-    if (it->log != NULL) {
-        free(it->log);
-    }*/
     coraza_free_transaction(transaction);
 
     logCbDump();
+    logCbClearLog();
 
     return ret;
 }

--- a/src/engines/ftwcoraza/ftwcoraza.h
+++ b/src/engines/ftwcoraza/ftwcoraza.h
@@ -25,8 +25,7 @@
 #define FTW_ENGINE_CORAZA
 #ifdef HAVE_LIBCORAZA
 
-#include <coraza/core.h>
-#include <coraza/utils.h>
+#include <coraza/coraza.h>
 
 #define N_INTERVENTION_STATUS 200
 

--- a/src/main.c
+++ b/src/main.c
@@ -265,6 +265,10 @@ strcpy(available_engines[engine_count++], "coraza");
             qsort(tests, test_count, sizeof(char *), walkcmp);
             for(int i = 0; i < test_count; i++) {
                 yaml_item *yrootsub = parse_yaml(tests[i]);
+                if (yrootsub == NULL) {
+                    fprintf(stderr, "Error: failed to parse YAML file: %s\n", tests[i]);
+                    continue;
+                }
                 ftwtestcollection * collection = ftwtestcollection_new(yrootsub, rule_test, rule_test_id);
                 if (collection == NULL) {
                     fprintf(stderr, "Error parsing file %s! (Memory allocation error)\n", tests[i]);


### PR DESCRIPTION
## Summary
- Update build system: `coraza/coraza.h`, `libcoraza`, config-based WAF creation
- Rewrite coraza init/cleanup for the new config-based API (`coraza_new_waf_config`, `coraza_new_waf`, `coraza_free_waf_config`)
- Fix WAF handle: use `engine->rules` (where the WAF is stored), not `engine->engine_instance` (stale config)
- Add error callback via `coraza_add_error_callback` for log capture
- Add `expect_ids`/`no_expect_ids` support for CRS 4.x test format
- Fix crash on empty YAML test files like 920539.yaml
- Fix engine name in summary output